### PR TITLE
Fix: align clock icon in Recently Viewed sidebar

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -191,10 +191,16 @@ main h1::after {
     background-color: #f8f9fa;
     border: 1px solid #dee2e6;
     border-radius: 8px;
-    padding: 15px;
+    padding: 12px 15px;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
     font-family: sans-serif;
     z-index: 1000; 
+}
+
+/* Custom fix for clock icon misalignment in collapsed state */
+.recently-viewed-sidebar h2 {
+    /* Nudges the icon up slightly when collapsed */
+    transform: translateY(-2px); 
 }
 
 .recently-viewed-sidebar:hover {
@@ -275,6 +281,16 @@ main h1::after {
     background-color: #dc3545;
     color: white;
 }
+
+/* Fix Recently Viewed clock alignment */
+.recently-viewed-sidebar h2 {
+    display: flex;
+    align-items: center; /* vertical center */
+    gap: 6px; /* gap between emoji and text */
+    font-size: 1.2rem;
+    color: #343a40;
+}
+
 
 /* @media (max-width: 992px) {
     .recently-viewed-sidebar {


### PR DESCRIPTION
## Pull Request

### Description
Aligned the clock (🕒) icon properly with the "Recently Viewed" text in the sidebar.  
The icon was previously shifted downwards. This fix adjusts the padding and nudges the icon slightly upward for perfect vertical alignment.

Fixes: #31

---

### 📸 Screenshots
**Before:** The clock icon was slightly misaligned with the text.  
<img width="868" height="406" alt="Screenshot 2025-10-02 at 12 10 03 AM" src="https://github.com/user-attachments/assets/887ec03a-cd93-490a-92ab-6b23836b67a8" />

**After:** The clock icon is now vertically centered and aligned with "Recently Viewed".
<img width="1366" height="768" alt="Screenshot 2025-10-02 at 6 58 40 PM" src="https://github.com/user-attachments/assets/ab0dc8f6-2de7-4ff3-ba77-ff2eacd0dcb8" />
<img width="1366" height="768" alt="Screenshot 2025-10-02 at 6 58 34 PM" src="https://github.com/user-attachments/assets/e36ad5c2-1f2e-4292-a329-608a78c22dfe" />


---

### ✅ Checklist
-  My code follows the project’s guidelines and style.
-  I have tested the changes and confirmed they work as expected.
-My PR is linked to a GitHub issue.

---

###  Additional Notes
- This is my first Hacktoberfest contribution for this repository .
- Learned how to properly create a branch, commit changes, and push for a PR.
