### PR TITLE
 Fix: Add missing breadcrumbs to all Topic pages

### DIFF
--- a/Arrays/arrays.html
+++ b/Arrays/arrays.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Arrays</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
 
@@ -23,6 +24,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Arrays</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Array Topics</h1>

--- a/BinarySearch/binarySearch.html
+++ b/BinarySearch/binarySearch.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Binary Search</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Binary Search Topics</h1>

--- a/BinarySearchTrees/bst.html
+++ b/BinarySearchTrees/bst.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search Trees</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Binary Search Trees</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Binary Search Tree (BST) Topics</h1>

--- a/BinaryTrees/binaryTrees.html
+++ b/BinaryTrees/binaryTrees.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Trees</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Binary Trees</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Binary Tree Topics</h1>

--- a/Dynamic_Programming/dp.html
+++ b/Dynamic_Programming/dp.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Dynamic Programming</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Dynamic Programming</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Dynamic Programming Topics</h1>

--- a/Graphs/graph.html
+++ b/Graphs/graph.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Graphs</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Graphs</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Graph Topics</h1>

--- a/Heaps/heap.html
+++ b/Heaps/heap.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Heaps</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Heaps</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Heap Topics</h1>

--- a/LinkedList/LL.html
+++ b/LinkedList/LL.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Linked List</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Linked Lists</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Linked List Topics</h1>

--- a/Recursion/recursion.html
+++ b/Recursion/recursion.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Recursion</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Recursion</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Recursion Topics</h1>

--- a/StacksAndQueues/stackAndQueue.html
+++ b/StacksAndQueues/stackAndQueue.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Stack & Queue</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Stacks & Queues</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Stack & Queue Topics</h1>

--- a/Strings/String.html
+++ b/Strings/String.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Strings</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Strings</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>String Topics</h1>

--- a/Tries/tries.html
+++ b/Tries/tries.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Tries</title>
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
+    <link rel="stylesheet" href="../CSS/breadcrumb.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
   <body>
@@ -22,6 +23,16 @@
         </button>
       </div>
     </nav>
+
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb-container">
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Tries</li>
+        </ol>
+      </nav>
+    </div>
 
     <main>
       <h1>Trie Topics</h1>


### PR DESCRIPTION
- Added breadcrumb CSS link to all 12 topic pages
- Added breadcrumb HTML structure (Home > Topic Name)
- Fixed navigation consistency across Arrays, LinkedList, StacksAndQueues, Strings, Recursion, BinarySearch, Heaps, BinaryTrees, BinarySearchTrees, Graphs, Dynamic Programming, and Tries pages
- Breadcrumbs now display uniformly on Contact, About, Problem, and Topic pages

Resolves: Missing breadcrumb navigation on Topic pages

## 🚀 Pull Request

### 🔖 Description
<!-- Please include a summary of the change and which issue is fixed. -->

Fixes: # (issue number)

---

### 📸 Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help us understand your changes. -->

---

### ✅ Checklist

- [ ] My code follows the project’s guidelines and style.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] I have tested the changes and confirmed they work as expected.
- [ ] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes
<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->