### PR TITLE
Add breadcrumb navigation to topic pages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/Arrays/arrays.html
+++ b/Arrays/arrays.html
@@ -1,115 +1,112 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Arrays</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
 
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Arrays</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-    <main>
-      <h1>Array Topics</h1>
-      <p class="intro-text">
-        Explore popular array problems and patterns to master your DSA skills.
-      </p>
-
-      <ul class="topic-list">
-        <a href="./Problems/twoSum.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Two Sum</span>
-          <span class="topic-desc"
-            >Classic problem: find two numbers that sum to target
-          </span>
-        </a>
-
-        <a href="./Problems/subarray.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name">Maximum Subarray</span>
-          <span class="topic-desc"
-            >Sliding window/Kadane's algorithm to find max contiguous sum
-          </span>
-        </a>
-
-        <a href="./Problems/prodOfArray.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Product of Array Except Self</span>
-          <span class="topic-desc"
-            >Prefix/suffix product array without using division
-          </span>
-        </a>
-
-        <a href="./Problems/ContainerWater.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">Container With Most Water</span>
-          <span class="topic-desc"
-            >Two-pointer technique to maximize area between lines
-          </span>
-        </a>
-
-        <a href="./Problems/trappingRainwater.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">Trapping Rain Water</span>
-          <span class="topic-desc"
-            >Compute trapped water using stack/two-pointer techniques
-          </span>
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        This set of problems covers most <em>array-related patterns</em> asked
-        in FAANG interviews: <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Arrays</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Two Sum</span> →
-        <span class="pattern-desc">Hashing, complement, pair sum problem.</span
-        ><br />
-        <span class="pattern-name">Maximum Subarray</span> →
-        <span class="pattern-desc"
-          >Sliding window / Kadane’s algorithm, contiguous subarray sum.</span
-        ><br />
-        <span class="pattern-name">Product of Array Except Self</span> →
-        <span class="pattern-desc"
-          >Prefix/suffix product, space optimization.</span
-        ><br />
-        <span class="pattern-name">Container With Most Water</span> →
-        <span class="pattern-desc">Two-pointer approach for optimization.</span
-        ><br />
-        <span class="pattern-name">Trapping Rain Water</span> →
-        <span class="pattern-desc"
-          >Stack, two-pointer technique, and elevation map problem.</span
-        ><br /><br />
+  <main>
+    <h1>Array Topics</h1>
+    <p class="intro-text">
+      Explore popular array problems and patterns to master your DSA skills.
+    </p>
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >sliding window, two-pointer, prefix-suffix, hash-based search, and
-          stack patterns</span
-        >
-        in arrays.
-      </p>
-    </main>
+    <ul class="topic-list">
+      <a href="./Problems/twoSum.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Two Sum</span>
+        <span class="topic-desc">Classic problem: find two numbers that sum to target
+        </span>
+      </a>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+      <a href="./Problems/subarray.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Maximum Subarray</span>
+        <span class="topic-desc">Sliding window/Kadane's algorithm to find max contiguous sum
+        </span>
+      </a>
 
-    <script src="../index.js"></script>
-  </body>
+      <a href="./Problems/prodOfArray.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Product of Array Except Self</span>
+        <span class="topic-desc">Prefix/suffix product array without using division
+        </span>
+      </a>
+
+      <a href="./Problems/ContainerWater.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">Container With Most Water</span>
+        <span class="topic-desc">Two-pointer technique to maximize area between lines
+        </span>
+      </a>
+
+      <a href="./Problems/trappingRainwater.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">Trapping Rain Water</span>
+        <span class="topic-desc">Compute trapped water using stack/two-pointer techniques
+        </span>
+      </a>
+    </ul>
+
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      This set of problems covers most <em>array-related patterns</em> asked
+      in FAANG interviews: <br /><br />
+
+      <span class="pattern-name">Two Sum</span> →
+      <span class="pattern-desc">Hashing, complement, pair sum problem.</span><br />
+      <span class="pattern-name">Maximum Subarray</span> →
+      <span class="pattern-desc">Sliding window / Kadane’s algorithm, contiguous subarray sum.</span><br />
+      <span class="pattern-name">Product of Array Except Self</span> →
+      <span class="pattern-desc">Prefix/suffix product, space optimization.</span><br />
+      <span class="pattern-name">Container With Most Water</span> →
+      <span class="pattern-desc">Two-pointer approach for optimization.</span><br />
+      <span class="pattern-name">Trapping Rain Water</span> →
+      <span class="pattern-desc">Stack, two-pointer technique, and elevation map problem.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">sliding window, two-pointer, prefix-suffix, hash-based search, and
+        stack patterns</span>
+      in arrays.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/BinarySearch/binarySearch.html
+++ b/BinarySearch/binarySearch.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,15 @@
         </button>
       </div>
     </nav>
+
+    <div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Binary Search</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Binary Search Topics</h1>

--- a/BinarySearchTrees/bst.html
+++ b/BinarySearchTrees/bst.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search Trees</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,14 @@
         </button>
       </div>
     </nav>
+<div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Binary Search Trees</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Binary Search Tree (BST) Topics</h1>

--- a/BinaryTrees/binaryTrees.html
+++ b/BinaryTrees/binaryTrees.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Trees</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,15 @@
         </button>
       </div>
     </nav>
+
+    <div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Binary Trees</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Binary Tree Topics</h1>

--- a/Dynamic_Programming/dp.html
+++ b/Dynamic_Programming/dp.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Dynamic Programming</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,15 @@
         </button>
       </div>
     </nav>
+
+    <div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Dynamic Programming</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Dynamic Programming Topics</h1>

--- a/Graphs/graph.html
+++ b/Graphs/graph.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Graphs</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,15 @@
         </button>
       </div>
     </nav>
+
+    <div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Graphs</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Graph Topics</h1>

--- a/Heaps/heap.html
+++ b/Heaps/heap.html
@@ -1,113 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Heaps</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
 
-    <main>
-      <h1>Heap Topics</h1>
-      <p class="intro-text">
-        Master essential heap problems and patterns frequently asked in
-        interviews.
-      </p>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Heaps</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-      <ul class="topic-list">
-        <a href="./Problems/kthLargest.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Kth Largest / Smallest Element</span>
-          <span class="topic-desc"
-            >Find Kth largest or smallest using min/max heap</span
-          >
-        </a>
-        <a href="./Problems/mergeKSorted.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name">Merge K Sorted Arrays / Lists</span>
-          <span class="topic-desc"
-            >Use min-heap to efficiently merge multiple sorted lists</span
-          >
-        </a>
-        <a href="./Problems/heapSort.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Heap Sort</span>
-          <span class="topic-desc"
-            >Classic sorting algorithm using max-heap</span
-          >
-        </a>
-        <a href="./Problems/topKFrequent.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">Top K Frequent Elements</span>
-          <span class="topic-desc"
-            >Use heap to track most frequent elements efficiently</span
-          >
-        </a>
-        <a href="./Problems/slidingWindowMedian.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">Sliding Window Median</span>
-          <span class="topic-desc"
-            >Maintain two heaps to find median in a sliding window</span
-          >
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        These problems cover the most <em>important heap patterns</em> for
-        interviews: <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Heaps</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Kth Largest / Smallest Element</span> →
-        <span class="pattern-desc"
-          >Use min/max heap to maintain top k elements efficiently.</span
-        ><br />
-        <span class="pattern-name">Merge K Sorted Arrays / Lists</span> →
-        <span class="pattern-desc"
-          >Min-heap to merge multiple streams in O(n log k).</span
-        ><br />
-        <span class="pattern-name">Heap Sort</span> →
-        <span class="pattern-desc"
-          >Build a heap and repeatedly extract max/min for sorting.</span
-        ><br />
-        <span class="pattern-name">Top K Frequent Elements</span> →
-        <span class="pattern-desc"
-          >Use heap to track k most frequent elements.</span
-        ><br />
-        <span class="pattern-name">Sliding Window Median</span> →
-        <span class="pattern-desc"
-          >Two-heap approach to maintain median dynamically in a window.</span
-        ><br /><br />
+  <main>
+    <h1>Heap Topics</h1>
+    <p class="intro-text">
+      Master essential heap problems and patterns frequently asked in
+      interviews.
+    </p>
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >min/max heaps, top k elements, merge patterns, heap-based sorting,
-          and dynamic median tracking</span
-        >
-        in heap problems.
-      </p>
-    </main>
+    <ul class="topic-list">
+      <a href="./Problems/kthLargest.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Kth Largest / Smallest Element</span>
+        <span class="topic-desc">Find Kth largest or smallest using min/max heap</span>
+      </a>
+      <a href="./Problems/mergeKSorted.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Merge K Sorted Arrays / Lists</span>
+        <span class="topic-desc">Use min-heap to efficiently merge multiple sorted lists</span>
+      </a>
+      <a href="./Problems/heapSort.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Heap Sort</span>
+        <span class="topic-desc">Classic sorting algorithm using max-heap</span>
+      </a>
+      <a href="./Problems/topKFrequent.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">Top K Frequent Elements</span>
+        <span class="topic-desc">Use heap to track most frequent elements efficiently</span>
+      </a>
+      <a href="./Problems/slidingWindowMedian.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">Sliding Window Median</span>
+        <span class="topic-desc">Maintain two heaps to find median in a sliding window</span>
+      </a>
+    </ul>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      These problems cover the most <em>important heap patterns</em> for
+      interviews: <br /><br />
 
-    <script src="../index.js"></script>
-  </body>
+      <span class="pattern-name">Kth Largest / Smallest Element</span> →
+      <span class="pattern-desc">Use min/max heap to maintain top k elements efficiently.</span><br />
+      <span class="pattern-name">Merge K Sorted Arrays / Lists</span> →
+      <span class="pattern-desc">Min-heap to merge multiple streams in O(n log k).</span><br />
+      <span class="pattern-name">Heap Sort</span> →
+      <span class="pattern-desc">Build a heap and repeatedly extract max/min for sorting.</span><br />
+      <span class="pattern-name">Top K Frequent Elements</span> →
+      <span class="pattern-desc">Use heap to track k most frequent elements.</span><br />
+      <span class="pattern-name">Sliding Window Median</span> →
+      <span class="pattern-desc">Two-heap approach to maintain median dynamically in a window.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">min/max heaps, top k elements, merge patterns, heap-based sorting,
+        and dynamic median tracking</span>
+      in heap problems.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/LinkedList/LL.html
+++ b/LinkedList/LL.html
@@ -1,111 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Linked List</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
 
-    <main>
-      <h1>Linked List Topics</h1>
-      <p class="intro-text">
-        Master essential linked list problems and patterns frequently asked in
-        interviews.
-      </p>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Linked List</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-      <ul class="topic-list">
-        <a href="./Problems/ReverseLL.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Reverse Linked List</span>
-          <span class="topic-desc"
-            >Iterative and recursive reversal of a linked list</span
-          >
-        </a>
-        <a href="./Problems/DetectCycle.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name">Detect Cycle in Linked List</span>
-          <span class="topic-desc"
-            >Floyd's cycle detection algorithm (slow & fast pointers)</span
-          >
-        </a>
-        <a href="./Problems/MergeSortedLL.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Merge Two Sorted Lists</span>
-          <span class="topic-desc">Classic merging problem using pointers</span>
-        </a>
-        <a href="./Problems/Palindrome.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">Palindrome Linked List</span>
-          <span class="topic-desc"
-            >Check palindrome using reverse second half technique</span
-          >
-        </a>
-        <a href="./Problems/IntersectionLL.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">Intersection of Two Linked Lists</span>
-          <span class="topic-desc"
-            >Find the node where two lists intersect using pointer trick</span
-          >
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        These problems cover the most
-        <em>important linked list patterns</em> for interviews: <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Linked Lists</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Reverse Linked List</span> →
-        <span class="pattern-desc"
-          >Pointer manipulation, iterative & recursive techniques.</span
-        ><br />
-        <span class="pattern-name">Detect Cycle</span> →
-        <span class="pattern-desc"
-          >Floyd’s cycle detection (slow & fast pointers).</span
-        ><br />
-        <span class="pattern-name">Merge Two Sorted Lists</span> →
-        <span class="pattern-desc"
-          >Two-pointer merge, sorted order handling.</span
-        ><br />
-        <span class="pattern-name">Palindrome Linked List</span> →
-        <span class="pattern-desc"
-          >Middle finding, reversing, comparing halves.</span
-        ><br />
-        <span class="pattern-name">Intersection of Two Linked Lists</span> →
-        <span class="pattern-desc"
-          >Length difference trick, pointer redirection.</span
-        ><br /><br />
+  <main>
+    <h1>Linked List Topics</h1>
+    <p class="intro-text">
+      Master essential linked list problems and patterns frequently asked in
+      interviews.
+    </p>
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >pointer manipulation, cycle detection, two-pointer merge,
-          middle-finding, and intersection techniques</span
-        >
-        in linked lists.
-      </p>
-    </main>
+    <ul class="topic-list">
+      <a href="./Problems/ReverseLL.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Reverse Linked List</span>
+        <span class="topic-desc">Iterative and recursive reversal of a linked list</span>
+      </a>
+      <a href="./Problems/DetectCycle.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Detect Cycle in Linked List</span>
+        <span class="topic-desc">Floyd's cycle detection algorithm (slow & fast pointers)</span>
+      </a>
+      <a href="./Problems/MergeSortedLL.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Merge Two Sorted Lists</span>
+        <span class="topic-desc">Classic merging problem using pointers</span>
+      </a>
+      <a href="./Problems/Palindrome.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">Palindrome Linked List</span>
+        <span class="topic-desc">Check palindrome using reverse second half technique</span>
+      </a>
+      <a href="./Problems/IntersectionLL.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">Intersection of Two Linked Lists</span>
+        <span class="topic-desc">Find the node where two lists intersect using pointer trick</span>
+      </a>
+    </ul>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      These problems cover the most
+      <em>important linked list patterns</em> for interviews: <br /><br />
 
-    <script src="../index.js"></script>
-  </body>
+      <span class="pattern-name">Reverse Linked List</span> →
+      <span class="pattern-desc">Pointer manipulation, iterative & recursive techniques.</span><br />
+      <span class="pattern-name">Detect Cycle</span> →
+      <span class="pattern-desc">Floyd’s cycle detection (slow & fast pointers).</span><br />
+      <span class="pattern-name">Merge Two Sorted Lists</span> →
+      <span class="pattern-desc">Two-pointer merge, sorted order handling.</span><br />
+      <span class="pattern-name">Palindrome Linked List</span> →
+      <span class="pattern-desc">Middle finding, reversing, comparing halves.</span><br />
+      <span class="pattern-name">Intersection of Two Linked Lists</span> →
+      <span class="pattern-desc">Length difference trick, pointer redirection.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">pointer manipulation, cycle detection, two-pointer merge,
+        middle-finding, and intersection techniques</span>
+      in linked lists.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/Recursion/recursion.html
+++ b/Recursion/recursion.html
@@ -1,114 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Recursion</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
 
-    <main>
-      <h1>Recursion Topics</h1>
-      <p class="intro-text">
-        Master essential recursion problems and patterns frequently asked in
-        interviews.
-      </p>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Recursion</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-      <ul class="topic-list">
-        <a href="./Problems/factorial.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Factorial</span>
-          <span class="topic-desc"
-            >Classic recursion example, base and recursive cases</span
-          >
-        </a>
-        <a href="./Problems/fibonacci.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name">Fibonacci Sequence</span>
-          <span class="topic-desc"
-            >Recursive sequence generation with memoization</span
-          >
-        </a>
-        <a href="./Problems/powerSet.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Power Set / Subsets</span>
-          <span class="topic-desc"
-            >Backtracking pattern for generating all subsets</span
-          >
-        </a>
-        <a href="./Problems/stringPermutation.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">String Permutations</span>
-          <span class="topic-desc"
-            >Backtracking pattern for all permutations of a string</span
-          >
-        </a>
-        <a href="./Problems/nQueens.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">N-Queens Problem</span>
-          <span class="topic-desc"
-            >Backtracking with constraints to place queens safely</span
-          >
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        These problems cover the most
-        <em>important recursion and backtracking patterns</em> for interviews:
-        <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Recursion</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Factorial</span> →
-        <span class="pattern-desc"
-          >Basic recursion with base case and simple recursive call.</span
-        ><br />
-        <span class="pattern-name">Fibonacci Sequence</span> →
-        <span class="pattern-desc"
-          >Simple recursion, optimized with memoization / DP.</span
-        ><br />
-        <span class="pattern-name">Power Set / Subsets</span> →
-        <span class="pattern-desc"
-          >Backtracking, decision tree recursion pattern.</span
-        ><br />
-        <span class="pattern-name">String Permutations</span> →
-        <span class="pattern-desc"
-          >Recursive swapping / backtracking to generate all permutations.</span
-        ><br />
-        <span class="pattern-name">N-Queens Problem</span> →
-        <span class="pattern-desc"
-          >Constraint-based backtracking recursion pattern.</span
-        ><br /><br />
+  <main>
+    <h1>Recursion Topics</h1>
+    <p class="intro-text">
+      Master essential recursion problems and patterns frequently asked in
+      interviews.
+    </p>
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >base recursion, recursive sequence generation, subset generation,
-          permutation generation, and backtracking with constraints</span
-        >
-        in recursion problems.
-      </p>
-    </main>
+    <ul class="topic-list">
+      <a href="./Problems/factorial.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Factorial</span>
+        <span class="topic-desc">Classic recursion example, base and recursive cases</span>
+      </a>
+      <a href="./Problems/fibonacci.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Fibonacci Sequence</span>
+        <span class="topic-desc">Recursive sequence generation with memoization</span>
+      </a>
+      <a href="./Problems/powerSet.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Power Set / Subsets</span>
+        <span class="topic-desc">Backtracking pattern for generating all subsets</span>
+      </a>
+      <a href="./Problems/stringPermutation.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">String Permutations</span>
+        <span class="topic-desc">Backtracking pattern for all permutations of a string</span>
+      </a>
+      <a href="./Problems/nQueens.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">N-Queens Problem</span>
+        <span class="topic-desc">Backtracking with constraints to place queens safely</span>
+      </a>
+    </ul>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      These problems cover the most
+      <em>important recursion and backtracking patterns</em> for interviews:
+      <br /><br />
 
-    <script src="../index.js"></script>
-  </body>
+      <span class="pattern-name">Factorial</span> →
+      <span class="pattern-desc">Basic recursion with base case and simple recursive call.</span><br />
+      <span class="pattern-name">Fibonacci Sequence</span> →
+      <span class="pattern-desc">Simple recursion, optimized with memoization / DP.</span><br />
+      <span class="pattern-name">Power Set / Subsets</span> →
+      <span class="pattern-desc">Backtracking, decision tree recursion pattern.</span><br />
+      <span class="pattern-name">String Permutations</span> →
+      <span class="pattern-desc">Recursive swapping / backtracking to generate all permutations.</span><br />
+      <span class="pattern-name">N-Queens Problem</span> →
+      <span class="pattern-desc">Constraint-based backtracking recursion pattern.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">base recursion, recursive sequence generation, subset generation,
+        permutation generation, and backtracking with constraints</span>
+      in recursion problems.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/StacksAndQueues/stackAndQueue.html
+++ b/StacksAndQueues/stackAndQueue.html
@@ -1,107 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Stack & Queue</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
 
-    <main>
-      <h1>Stack & Queue Topics</h1>
-      <p class="intro-text">
-        Master essential stack and queue problems and patterns frequently asked
-        in interviews.
-      </p>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Stack & Queue</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-      <ul class="topic-list">
-        <a href="./Problems/validParentheses.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Valid Parentheses</span>
-          <span class="topic-desc">Balanced parentheses check using stack</span>
-        </a>
-        <a href="./Problems/MinStack.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name">Min Stack</span>
-          <span class="topic-desc">Design stack with O(1) min retrieval</span>
-        </a>
-        <a href="./Problems/NextGreater.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Next Greater Element</span>
-          <span class="topic-desc"
-            >Monotonic stack pattern for array problems</span
-          >
-        </a>
-        <a href="./Problems/ImplementQueueUsingStack.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">Implement Queue using Stacks</span>
-          <span class="topic-desc">Classic stack-to-queue conversion</span>
-        </a>
-        <a href="./Problems/slidingWindowMax.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">Sliding Window Maximum</span>
-          <span class="topic-desc"
-            >Deque-based optimization for window problems</span
-          >
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        These problems cover the most
-        <em>important stack and queue patterns</em> for interviews: <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Stacks & Queues</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Valid Parentheses</span> →
-        <span class="pattern-desc"
-          >Balanced brackets, stack push-pop matching.</span
-        ><br />
-        <span class="pattern-name">Min Stack</span> →
-        <span class="pattern-desc"
-          >Design problems, auxiliary stack technique.</span
-        ><br />
-        <span class="pattern-name">Next Greater Element</span> →
-        <span class="pattern-desc">Monotonic stack, array traversal.</span
-        ><br />
-        <span class="pattern-name">Implement Queue using Stacks</span> →
-        <span class="pattern-desc"
-          >Stack-Queue conversion, data structure simulation.</span
-        ><br />
-        <span class="pattern-name">Sliding Window Maximum</span> →
-        <span class="pattern-desc"
-          >Deque pattern, window-based optimization.</span
-        ><br /><br />
+  <main>
+    <h1>Stack & Queue Topics</h1>
+    <p class="intro-text">
+      Master essential stack and queue problems and patterns frequently asked
+      in interviews.
+    </p>
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >stack-based matching, design with auxiliary structures, monotonic
-          stack tricks, stack-to-queue conversions, and sliding window
-          optimization</span
-        >
-        using queues.
-      </p>
-    </main>
+    <ul class="topic-list">
+      <a href="./Problems/validParentheses.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Valid Parentheses</span>
+        <span class="topic-desc">Balanced parentheses check using stack</span>
+      </a>
+      <a href="./Problems/MinStack.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Min Stack</span>
+        <span class="topic-desc">Design stack with O(1) min retrieval</span>
+      </a>
+      <a href="./Problems/NextGreater.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Next Greater Element</span>
+        <span class="topic-desc">Monotonic stack pattern for array problems</span>
+      </a>
+      <a href="./Problems/ImplementQueueUsingStack.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">Implement Queue using Stacks</span>
+        <span class="topic-desc">Classic stack-to-queue conversion</span>
+      </a>
+      <a href="./Problems/slidingWindowMax.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">Sliding Window Maximum</span>
+        <span class="topic-desc">Deque-based optimization for window problems</span>
+      </a>
+    </ul>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      These problems cover the most
+      <em>important stack and queue patterns</em> for interviews: <br /><br />
 
-    <script src="../index.js"></script>
-  </body>
+      <span class="pattern-name">Valid Parentheses</span> →
+      <span class="pattern-desc">Balanced brackets, stack push-pop matching.</span><br />
+      <span class="pattern-name">Min Stack</span> →
+      <span class="pattern-desc">Design problems, auxiliary stack technique.</span><br />
+      <span class="pattern-name">Next Greater Element</span> →
+      <span class="pattern-desc">Monotonic stack, array traversal.</span><br />
+      <span class="pattern-name">Implement Queue using Stacks</span> →
+      <span class="pattern-desc">Stack-Queue conversion, data structure simulation.</span><br />
+      <span class="pattern-name">Sliding Window Maximum</span> →
+      <span class="pattern-desc">Deque pattern, window-based optimization.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">stack-based matching, design with auxiliary structures, monotonic
+        stack tricks, stack-to-queue conversions, and sliding window
+        optimization</span>
+      using queues.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/Strings/String.html
+++ b/Strings/String.html
@@ -1,118 +1,107 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CodeDSA Strings</title>
-    <link rel="stylesheet" href="../CSS/AllTopics.css" />
-    <link rel="stylesheet" href="../CSS/snake.css" />
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar">
-      <div class="logo">CodeDSA</div>
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="../index.html">Home</a></li>
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../contact.html">Contact</a></li>
-        </ul>
-        <button id="snakeToggle" class="snake-btn">
-          <span style="margin-left: 20px">Snake Cursor</span>
-        </button>
-      </div>
-    </nav>
 
-    <main>
-      <h1>String Topics</h1>
-      <p class="intro-text">
-        Master essential string problems and patterns frequently asked in
-        interviews.
-      </p>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeDSA Strings</title>
+  <link rel="stylesheet" href="../CSS/breadcrumb.css">
+  <link rel="stylesheet" href="../CSS/AllTopics.css" />
+  <link rel="stylesheet" href="../CSS/snake.css" />
+</head>
 
-      <ul class="topic-list">
-        <a href="./Problems/longestPalinSubstring.html">
-          <span class="topic-number">01</span>
-          <span class="topic-name">Longest Palindromic Substring</span>
-          <span class="topic-desc"
-            >Find the longest substring that is a palindrome</span
-          >
-        </a>
-        <a href="./Problems/longestSubstringWithoutRepeat.html">
-          <span class="topic-number">02</span>
-          <span class="topic-name"
-            >Longest Substring Without Repeating Characters</span
-          >
-          <span class="topic-desc"
-            >Sliding window pattern to track unique characters</span
-          >
-        </a>
-        <a href="./Problems/validAnagrams.html">
-          <span class="topic-number">03</span>
-          <span class="topic-name">Valid Anagram</span>
-          <span class="topic-desc"
-            >Hash map pattern to check frequency of characters</span
-          >
-        </a>
-        <a href="./Problems/groupAnagrams.html">
-          <span class="topic-number">04</span>
-          <span class="topic-name">Group Anagrams</span>
-          <span class="topic-desc"
-            >Sorting & hash-based grouping of strings</span
-          >
-        </a>
-        <a href="./Problems/Matching.html">
-          <span class="topic-number">05</span>
-          <span class="topic-name">String Matching / Pattern Matching</span>
-          <span class="topic-desc"
-            >KMP / Rabin-Karp algorithm for substring search</span
-          >
-        </a>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="logo">CodeDSA</div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../about.html">About</a></li>
+        <li><a href="../contact.html">Contact</a></li>
       </ul>
+      <button id="snakeToggle" class="snake-btn">
+        <span style="margin-left: 20px">Snake Cursor</span>
+      </button>
+    </div>
+  </nav>
 
-      <p class="pattern-coverage">
-        <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
-        These problems cover the most <em>important string patterns</em> for
-        interviews: <br /><br />
+  <div class="breadcrumb-container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Strings</li>
+      </ol>
+    </nav>
+  </div>
 
-        <span class="pattern-name">Longest Palindromic Substring</span> →
-        <span class="pattern-desc"
-          >Expand around center, dynamic programming, palindrome checking.</span
-        ><br />
-        <span class="pattern-name"
-          >Longest Substring Without Repeating Characters</span
-        >
-        →
-        <span class="pattern-desc"
-          >Sliding window, hash map to track characters.</span
-        ><br />
-        <span class="pattern-name">Valid Anagram</span> →
-        <span class="pattern-desc">Hashing frequency counts, comparison.</span
-        ><br />
-        <span class="pattern-name">Group Anagrams</span> →
-        <span class="pattern-desc"
-          >Sort string or use character count as key in hash map.</span
-        ><br />
-        <span class="pattern-name">String Matching / Pattern Matching</span> →
-        <span class="pattern-desc"
-          >KMP algorithm, rolling hash (Rabin-Karp) for efficient substring
-          search.</span
-        ><br /><br />
 
-        Together, they ensure you understand
-        <span class="highlight"
-          >palindromes, sliding window, hash-based frequency, grouping, and
-          efficient substring search techniques</span
-        >
-        in strings.
-      </p>
-    </main>
+  <main>
+    <h1>String Topics</h1>
+    <p class="intro-text">
+      Master essential string problems and patterns frequently asked in
+      interviews.
+    </p>
 
-    <!-- Footer -->
-    <footer>
-      <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
-    </footer>
+    <ul class="topic-list">
+      <a href="./Problems/longestPalinSubstring.html">
+        <span class="topic-number">01</span>
+        <span class="topic-name">Longest Palindromic Substring</span>
+        <span class="topic-desc">Find the longest substring that is a palindrome</span>
+      </a>
+      <a href="./Problems/longestSubstringWithoutRepeat.html">
+        <span class="topic-number">02</span>
+        <span class="topic-name">Longest Substring Without Repeating Characters</span>
+        <span class="topic-desc">Sliding window pattern to track unique characters</span>
+      </a>
+      <a href="./Problems/validAnagrams.html">
+        <span class="topic-number">03</span>
+        <span class="topic-name">Valid Anagram</span>
+        <span class="topic-desc">Hash map pattern to check frequency of characters</span>
+      </a>
+      <a href="./Problems/groupAnagrams.html">
+        <span class="topic-number">04</span>
+        <span class="topic-name">Group Anagrams</span>
+        <span class="topic-desc">Sorting & hash-based grouping of strings</span>
+      </a>
+      <a href="./Problems/Matching.html">
+        <span class="topic-number">05</span>
+        <span class="topic-name">String Matching / Pattern Matching</span>
+        <span class="topic-desc">KMP / Rabin-Karp algorithm for substring search</span>
+      </a>
+    </ul>
 
-    <script src="../index.js"></script>
-  </body>
+    <p class="pattern-coverage">
+      <strong>WONDERING, HOW DOES IT COVER PATTERNS?</strong> <br />
+      These problems cover the most <em>important string patterns</em> for
+      interviews: <br /><br />
+
+      <span class="pattern-name">Longest Palindromic Substring</span> →
+      <span class="pattern-desc">Expand around center, dynamic programming, palindrome checking.</span><br />
+      <span class="pattern-name">Longest Substring Without Repeating Characters</span>
+      →
+      <span class="pattern-desc">Sliding window, hash map to track characters.</span><br />
+      <span class="pattern-name">Valid Anagram</span> →
+      <span class="pattern-desc">Hashing frequency counts, comparison.</span><br />
+      <span class="pattern-name">Group Anagrams</span> →
+      <span class="pattern-desc">Sort string or use character count as key in hash map.</span><br />
+      <span class="pattern-name">String Matching / Pattern Matching</span> →
+      <span class="pattern-desc">KMP algorithm, rolling hash (Rabin-Karp) for efficient substring
+        search.</span><br /><br />
+
+      Together, they ensure you understand
+      <span class="highlight">palindromes, sliding window, hash-based frequency, grouping, and
+        efficient substring search techniques</span>
+      in strings.
+    </p>
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <p>&copy; 2025 Mrunalini Pachpute. All rights reserved.</p>
+  </footer>
+
+  <script src="../index.js"></script>
+</body>
+
 </html>

--- a/Tries/tries.html
+++ b/Tries/tries.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Tries</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,6 +23,15 @@
         </button>
       </div>
     </nav>
+
+    <div class="breadcrumb-container">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Tries</li>
+    </ol>
+  </nav>
+</div>
 
     <main>
       <h1>Trie Topics</h1>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

Added breadcrumb navigation to all topic pages in the CodeDSA website. This improves navigation by showing users the path they are on (e.g., Home > Arrays > Two Sum). The breadcrumbs are sticky, mobile-responsive, and consistent across all topics.

Fixes: #46

---

### 📸 Screenshots (if applicable)

<img width="1918" height="877" alt="Screenshot 2025-10-03 154958" src="https://github.com/user-attachments/assets/73a2b910-5743-4849-a2a5-5c995320fae9" />



---

### ✅ Checklist

- ✅  My code follows the project’s guidelines and style.
- ✅ I have commented my code where necessary.
- ✅ I have updated the documentation if needed.
- ✅  I have tested the changes and confirmed they work as expected.
- ✅  My PR is linked to a GitHub issue.

---