### PR TITLE
Add topics filter above problem cards and new topicsFilter.css (Issue #55)

### DIFF
--- a/CSS/topicsFilter.css
+++ b/CSS/topicsFilter.css
@@ -14,42 +14,92 @@
   font-weight: 600;
 }
 
-.filter-checkboxes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
+/* Dropdown Styles */
+.filter-dropdown {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  max-width: 300px;
 }
 
-.filter-checkboxes label {
+.dropdown-toggle {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background-color: #fff;
-  border: 2px solid #ddd;
+  width: 100%;
+  padding: 12px 16px;
+  background-color: #007bff;
+  color: white;
+  border: none;
   border-radius: 6px;
   cursor: pointer;
+  font-size: 1em;
+  font-weight: 500;
   transition: all 0.3s ease;
-  font-size: 0.95em;
-  color: #555;
+  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.3);
+}
+
+.dropdown-toggle:hover {
+  background-color: #0056b3;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 123, 255, 0.4);
+}
+
+.dropdown-toggle:active {
+  transform: translateY(0);
+}
+
+.dropdown-arrow {
+  font-size: 0.8em;
+  margin-left: 10px;
+  transition: transform 0.3s ease;
+}
+
+.dropdown-content {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 8px;
+  background-color: #fff;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  z-index: 1000;
+}
+
+.dropdown-content.show {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+.dropdown-content label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border-radius: 4px;
   user-select: none;
 }
 
-.filter-checkboxes label:hover {
-  border-color: #007bff;
+.dropdown-content label:hover {
   background-color: #f0f7ff;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 123, 255, 0.2);
 }
 
-.filter-checkboxes input[type='checkbox'] {
+.dropdown-content input[type='checkbox'] {
   width: 18px;
   height: 18px;
   cursor: pointer;
   accent-color: #007bff;
 }
 
-.filter-checkboxes input[type='checkbox']:checked + span {
+.dropdown-content input[type='checkbox']:checked ~ span {
   color: #007bff;
   font-weight: 600;
 }
@@ -59,13 +109,18 @@
   .topics-filter-container {
     padding: 15px;
   }
-
-  .filter-checkboxes {
-    gap: 10px;
+  
+  .filter-dropdown {
+    max-width: 100%;
   }
-
-  .filter-checkboxes label {
-    padding: 6px 10px;
+  
+  .dropdown-toggle {
+    padding: 10px 14px;
+    font-size: 0.95em;
+  }
+  
+  .dropdown-content label {
+    padding: 8px 10px;
     font-size: 0.9em;
   }
 }

--- a/CSS/topicsFilter.css
+++ b/CSS/topicsFilter.css
@@ -1,0 +1,71 @@
+/* Topics Filter Styles */
+.topics-filter-container {
+  margin: 20px 0;
+  padding: 20px;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.topics-filter-container h3 {
+  margin: 0 0 15px 0;
+  color: #333;
+  font-size: 1.2em;
+  font-weight: 600;
+}
+
+.filter-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.filter-checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: #fff;
+  border: 2px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-size: 0.95em;
+  color: #555;
+  user-select: none;
+}
+
+.filter-checkboxes label:hover {
+  border-color: #007bff;
+  background-color: #f0f7ff;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 123, 255, 0.2);
+}
+
+.filter-checkboxes input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #007bff;
+}
+
+.filter-checkboxes input[type='checkbox']:checked + span {
+  color: #007bff;
+  font-weight: 600;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .topics-filter-container {
+    padding: 15px;
+  }
+
+  .filter-checkboxes {
+    gap: 10px;
+  }
+
+  .filter-checkboxes label {
+    padding: 6px 10px;
+    font-size: 0.9em;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,8 +6,8 @@
     <title>My Topics Home</title>
     <link rel="stylesheet" href="CSS/index.css" />
     <link rel="stylesheet" href="CSS/snake.css" />
+    <link rel="stylesheet" href="CSS/topicsFilter.css" />
   </head>
-
   <body>
     <!-- Navbar -->
     <nav class="navbar">
@@ -23,76 +23,93 @@
         </button>
       </div>
     </nav>
-
     <!-- Main Content -->
     <div class="home-container">
       <main>
         <h1>Explore Topics</h1>
+        
+        <!-- Topics Filter -->
+        <div class="topics-filter-container">
+          <h3>Filter by Topics:</h3>
+          <div class="filter-checkboxes">
+            <label><input type="checkbox" class="topic-filter" value="arrays" checked> Arrays</label>
+            <label><input type="checkbox" class="topic-filter" value="linkedlist" checked> Linked Lists</label>
+            <label><input type="checkbox" class="topic-filter" value="stacks" checked> Stacks & Queues</label>
+            <label><input type="checkbox" class="topic-filter" value="strings" checked> Strings</label>
+            <label><input type="checkbox" class="topic-filter" value="recursion" checked> Recursion</label>
+            <label><input type="checkbox" class="topic-filter" value="binarysearch" checked> Binary Search</label>
+            <label><input type="checkbox" class="topic-filter" value="heaps" checked> Heaps</label>
+            <label><input type="checkbox" class="topic-filter" value="binarytrees" checked> Binary Trees</label>
+            <label><input type="checkbox" class="topic-filter" value="bst" checked> Binary Search Trees</label>
+            <label><input type="checkbox" class="topic-filter" value="graphs" checked> Graphs</label>
+            <label><input type="checkbox" class="topic-filter" value="dp" checked> Dynamic Programming</label>
+            <label><input type="checkbox" class="topic-filter" value="tries" checked> Tries</label>
+          </div>
+        </div>
+        
         <div class="card-container">
-          <a class="card" href="./Arrays/arrays.html">
+          <a class="card" data-topic="arrays" href="./Arrays/arrays.html">
             <h3>Arrays</h3>
             <p>Problems related to arrays (TwoSum, MaximumSubarray, ...)</p>
           </a>
-          <a class="card" href="./LinkedList/LL.html">
+          <a class="card" data-topic="linkedlist" href="./LinkedList/LL.html">
             <h3>Linked Lists</h3>
             <p>Single, double, circular linked list problems</p>
           </a>
-          <a class="card" href="./StacksAndQueues/stackAndQueue.html">
+          <a class="card" data-topic="stacks" href="./StacksAndQueues/stackAndQueue.html">
             <h3>Stacks & Queues</h3>
             <p>Stack and Queue related problems</p>
           </a>
-          <a class="card" href="./Strings/String.html">
+          <a class="card" data-topic="strings" href="./Strings/String.html">
             <h3>Strings</h3>
             <p>String manipulation problems</p>
           </a>
-          <a class="card" href="./Recursion/recursion.html">
+          <a class="card" data-topic="recursion" href="./Recursion/recursion.html">
             <h3>Recursion</h3>
             <p>
               Recursive solutions and backtracking (Factorial, NQueens, ...)
             </p>
           </a>
-          <a class="card" href="./BinarySearch/binarySearch.html">
+          <a class="card" data-topic="binarysearch" href="./BinarySearch/binarySearch.html">
             <h3>Binary Search</h3>
             <p>Binary search and its variations</p>
           </a>
-          <a class="card" href="./Heaps/heap.html">
+          <a class="card" data-topic="heaps" href="./Heaps/heap.html">
             <h3>Heaps</h3>
             <p>Heap / PriorityQueue problems</p>
           </a>
-          <a class="card" href="./BinaryTrees/binaryTrees.html">
+          <a class="card" data-topic="binarytrees" href="./BinaryTrees/binaryTrees.html">
             <h3>Binary Trees</h3>
             <p>Binary tree problems (InorderTraversal, ...)</p>
           </a>
-          <a class="card" href="./BinarySearchTrees/bst.html">
+          <a class="card" data-topic="bst" href="./BinarySearchTrees/bst.html">
             <h3>Binary Search Trees</h3>
             <p>BST-specific problems (ValidateBST, ...)</p>
           </a>
-          <a class="card" href="./Graphs/graph.html">
+          <a class="card" data-topic="graphs" href="./Graphs/graph.html">
             <h3>Graphs</h3>
             <p>Graph algorithms (DFS, BFS, Dijkstra, ...)</p>
           </a>
-          <a class="card" href="./Dynamic_Programming/dp.html">
+          <a class="card" data-topic="dp" href="./Dynamic_Programming/dp.html">
             <h3>Dynamic Programming</h3>
             <p>DP problems (1D, 2D, memoization, tabulation)</p>
           </a>
-          <a class="card" href="./Tries/tries.html">
+          <a class="card" data-topic="tries" href="./Tries/tries.html">
             <h3>Tries</h3>
             <p>Trie / Prefix tree problems</p>
           </a>
         </div>
       </main>
       <aside class="recently-viewed-sidebar">
-        <h2>🕒<span> &nbsp;Recently Viewed</span></h2>
+        <h2>🕒 <span> Recently Viewed</span></h2>
         <ul id="recently-viewed-list"></ul>
         <button id="clear-history-btn">Clear History</button>
       </aside>
     </div>
-
     <!-- Footer -->
     <footer>
-      <p>&copy; 2025 CodeDSA. All rights reserved.</p>
+      <p>© 2025 CodeDSA. All rights reserved.</p>
     </footer>
-
     <script src="index.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,80 +28,85 @@
       <main>
         <h1>Explore Topics</h1>
         
-        <!-- Topics Filter -->
+        <!-- Topics Filter Dropdown -->
         <div class="topics-filter-container">
           <h3>Filter by Topics:</h3>
-          <div class="filter-checkboxes">
-            <label><input type="checkbox" class="topic-filter" value="arrays" checked> Arrays</label>
-            <label><input type="checkbox" class="topic-filter" value="linkedlist" checked> Linked Lists</label>
-            <label><input type="checkbox" class="topic-filter" value="stacks" checked> Stacks & Queues</label>
-            <label><input type="checkbox" class="topic-filter" value="strings" checked> Strings</label>
-            <label><input type="checkbox" class="topic-filter" value="recursion" checked> Recursion</label>
-            <label><input type="checkbox" class="topic-filter" value="binarysearch" checked> Binary Search</label>
-            <label><input type="checkbox" class="topic-filter" value="heaps" checked> Heaps</label>
-            <label><input type="checkbox" class="topic-filter" value="binarytrees" checked> Binary Trees</label>
-            <label><input type="checkbox" class="topic-filter" value="bst" checked> Binary Search Trees</label>
-            <label><input type="checkbox" class="topic-filter" value="graphs" checked> Graphs</label>
-            <label><input type="checkbox" class="topic-filter" value="dp" checked> Dynamic Programming</label>
-            <label><input type="checkbox" class="topic-filter" value="tries" checked> Tries</label>
+          <div class="filter-dropdown">
+            <button class="dropdown-toggle" id="topicsDropdownBtn">
+              Select Topics <span class="dropdown-arrow">▼</span>
+            </button>
+            <div class="dropdown-content" id="topicsDropdownContent">
+              <label><input type="checkbox" class="topic-filter" value="arrays" checked /> Arrays</label>
+              <label><input type="checkbox" class="topic-filter" value="linkedlist" checked /> Linked Lists</label>
+              <label><input type="checkbox" class="topic-filter" value="stacks" checked /> Stacks & Queues</label>
+              <label><input type="checkbox" class="topic-filter" value="strings" checked /> Strings</label>
+              <label><input type="checkbox" class="topic-filter" value="recursion" checked /> Recursion</label>
+              <label><input type="checkbox" class="topic-filter" value="binarysearch" checked /> Binary Search</label>
+              <label><input type="checkbox" class="topic-filter" value="heaps" checked /> Heaps</label>
+              <label><input type="checkbox" class="topic-filter" value="binarytrees" checked /> Binary Trees</label>
+              <label><input type="checkbox" class="topic-filter" value="bst" checked /> Binary Search Trees</label>
+              <label><input type="checkbox" class="topic-filter" value="graphs" checked /> Graphs</label>
+              <label><input type="checkbox" class="topic-filter" value="dp" checked /> Dynamic Programming</label>
+              <label><input type="checkbox" class="topic-filter" value="tries" checked /> Tries</label>
+            </div>
           </div>
         </div>
         
         <div class="card-container">
-          <a class="card" data-topic="arrays" href="./Arrays/arrays.html">
-            <h3>Arrays</h3>
+          <a href="./Arrays/arrays.html" class="card" data-topic="arrays">
+            <h2>Arrays</h2>
             <p>Problems related to arrays (TwoSum, MaximumSubarray, ...)</p>
           </a>
-          <a class="card" data-topic="linkedlist" href="./LinkedList/LL.html">
-            <h3>Linked Lists</h3>
+          <a href="./LinkedList/LL.html" class="card" data-topic="linkedlist">
+            <h2>Linked Lists</h2>
             <p>Single, double, circular linked list problems</p>
           </a>
-          <a class="card" data-topic="stacks" href="./StacksAndQueues/stackAndQueue.html">
-            <h3>Stacks & Queues</h3>
+          <a href="./StacksAndQueues/stackAndQueue.html" class="card" data-topic="stacks">
+            <h2>Stacks & Queues</h2>
             <p>Stack and Queue related problems</p>
           </a>
-          <a class="card" data-topic="strings" href="./Strings/String.html">
-            <h3>Strings</h3>
+          <a href="./Strings/String.html" class="card" data-topic="strings">
+            <h2>Strings</h2>
             <p>String manipulation problems</p>
           </a>
-          <a class="card" data-topic="recursion" href="./Recursion/recursion.html">
-            <h3>Recursion</h3>
+          <a href="./Recursion/recursion.html" class="card" data-topic="recursion">
+            <h2>Recursion</h2>
             <p>
               Recursive solutions and backtracking (Factorial, NQueens, ...)
             </p>
           </a>
-          <a class="card" data-topic="binarysearch" href="./BinarySearch/binarySearch.html">
-            <h3>Binary Search</h3>
+          <a href="./BinarySearch/binarySearch.html" class="card" data-topic="binarysearch">
+            <h2>Binary Search</h2>
             <p>Binary search and its variations</p>
           </a>
-          <a class="card" data-topic="heaps" href="./Heaps/heap.html">
-            <h3>Heaps</h3>
+          <a href="./Heaps/heap.html" class="card" data-topic="heaps">
+            <h2>Heaps</h2>
             <p>Heap / PriorityQueue problems</p>
           </a>
-          <a class="card" data-topic="binarytrees" href="./BinaryTrees/binaryTrees.html">
-            <h3>Binary Trees</h3>
+          <a href="./BinaryTrees/binaryTrees.html" class="card" data-topic="binarytrees">
+            <h2>Binary Trees</h2>
             <p>Binary tree problems (InorderTraversal, ...)</p>
           </a>
-          <a class="card" data-topic="bst" href="./BinarySearchTrees/bst.html">
-            <h3>Binary Search Trees</h3>
+          <a href="./BinarySearchTrees/bst.html" class="card" data-topic="bst">
+            <h2>Binary Search Trees</h2>
             <p>BST-specific problems (ValidateBST, ...)</p>
           </a>
-          <a class="card" data-topic="graphs" href="./Graphs/graph.html">
-            <h3>Graphs</h3>
+          <a href="./Graphs/graph.html" class="card" data-topic="graphs">
+            <h2>Graphs</h2>
             <p>Graph algorithms (DFS, BFS, Dijkstra, ...)</p>
           </a>
-          <a class="card" data-topic="dp" href="./Dynamic_Programming/dp.html">
-            <h3>Dynamic Programming</h3>
+          <a href="./Dynamic_Programming/dp.html" class="card" data-topic="dp">
+            <h2>Dynamic Programming</h2>
             <p>DP problems (1D, 2D, memoization, tabulation)</p>
           </a>
-          <a class="card" data-topic="tries" href="./Tries/tries.html">
-            <h3>Tries</h3>
+          <a href="./Tries/tries.html" class="card" data-topic="tries">
+            <h2>Tries</h2>
             <p>Trie / Prefix tree problems</p>
           </a>
         </div>
       </main>
       <aside class="recently-viewed-sidebar">
-        <h2>🕒 <span> Recently Viewed</span></h2>
+        <h2>🕒 Recently Viewed</h2>
         <ul id="recently-viewed-list"></ul>
         <button id="clear-history-btn">Clear History</button>
       </aside>

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ document.querySelectorAll('.flowchart-btn').forEach((btn) => {
     const container = btn.nextElementSibling; // find the div right after this button
     container.style.display =
       container.style.display === 'none' ? 'block' : 'none';
-
     // Optional: toggle button text
     btn.textContent =
       container.style.display === 'block' ? 'Hide Flowchart' : 'View Flowchart';
@@ -17,24 +16,20 @@ document.addEventListener('DOMContentLoaded', () => {
     // Check localStorage for saved snake state
     let snakeEnabled = localStorage.getItem('snakeEnabled') === 'true';
     let trail = [];
-
     // Initialize snake state based on saved preference
     if (snakeEnabled) {
       enableSnake();
     }
-
     toggleBtn.addEventListener('click', () => {
       snakeEnabled = !snakeEnabled;
       // Save state to localStorage
       localStorage.setItem('snakeEnabled', snakeEnabled);
-
       if (snakeEnabled) {
         enableSnake();
       } else {
         disableSnake();
       }
     });
-
     function enableSnake() {
       document.body.classList.add('snake-cursor');
       document.addEventListener('mousemove', drawSnake);
@@ -42,7 +37,6 @@ document.addEventListener('DOMContentLoaded', () => {
         '<span style="margin-left: 20px;">Disable Snake</span>';
       toggleBtn.classList.add('active');
     }
-
     function disableSnake() {
       document.body.classList.remove('snake-cursor');
       document.removeEventListener('mousemove', drawSnake);
@@ -51,7 +45,6 @@ document.addEventListener('DOMContentLoaded', () => {
         '<span style="margin-left: 20px;">Snake Cursor</span>';
       toggleBtn.classList.remove('active');
     }
-
     function drawSnake(e) {
       const seg = document.createElement('div');
       seg.className = 'snake-segment';
@@ -59,33 +52,27 @@ document.addEventListener('DOMContentLoaded', () => {
       seg.style.top = e.pageY + 'px';
       document.body.appendChild(seg);
       trail.push(seg);
-
       setTimeout(() => {
         seg.remove();
         trail.shift();
       }, 500);
     }
-
     function clearTrail() {
       trail.forEach((seg) => seg.remove());
       trail = [];
     }
   }
-
   // Recently Viewed Problems Logic
   const recentlyViewedList = document.getElementById('recently-viewed-list');
   const clearHistoryBtn = document.getElementById('clear-history-btn');
-
   // reads from localStorage and builds the HTML list
   function displayRecentProblems() {
     if (!recentlyViewedList) return; // Guard clause if element doesn't exist
-
     recentlyViewedList.innerHTML = '';
     const recentlyViewed =
       JSON.parse(localStorage.getItem('recentlyViewed')) || [];
-
     if (recentlyViewed.length === 0) {
-      recentlyViewedList.innerHTML = '<li>No recent problems viewed</li>';
+      recentlyViewedList.innerHTML = 'No recent problems viewed';
       if (clearHistoryBtn) clearHistoryBtn.style.display = 'none';
     } else {
       recentlyViewed.forEach((problem) => {
@@ -99,22 +86,45 @@ document.addEventListener('DOMContentLoaded', () => {
       if (clearHistoryBtn) clearHistoryBtn.style.display = 'block';
     }
   }
-
   //function to clear history on buttonclick
   function clearHistory() {
     localStorage.removeItem('recentlyViewed');
     displayRecentProblems();
   }
-
   if (clearHistoryBtn) {
     clearHistoryBtn.addEventListener('click', clearHistory);
   }
-
   if (recentlyViewedList) {
     displayRecentProblems();
   }
-});
 
+  // Topics Filter Logic
+  const topicFilters = document.querySelectorAll('.topic-filter');
+  const cards = document.querySelectorAll('.card[data-topic]');
+
+  if (topicFilters.length > 0 && cards.length > 0) {
+    topicFilters.forEach((checkbox) => {
+      checkbox.addEventListener('change', filterCards);
+    });
+
+    function filterCards() {
+      // Get all checked filter values
+      const checkedTopics = Array.from(topicFilters)
+        .filter((cb) => cb.checked)
+        .map((cb) => cb.value);
+
+      // Show/hide cards based on filter
+      cards.forEach((card) => {
+        const cardTopic = card.getAttribute('data-topic');
+        if (checkedTopics.includes(cardTopic)) {
+          card.style.display = '';
+        } else {
+          card.style.display = 'none';
+        }
+      });
+    }
+  }
+});
 function navigateTo(page) {
   window.location.href = page;
 }

--- a/index.js
+++ b/index.js
@@ -97,22 +97,38 @@ document.addEventListener('DOMContentLoaded', () => {
   if (recentlyViewedList) {
     displayRecentProblems();
   }
-
+  
+  // Topics Filter Dropdown Toggle Logic
+  const dropdownBtn = document.getElementById('topicsDropdownBtn');
+  const dropdownContent = document.getElementById('topicsDropdownContent');
+  
+  if (dropdownBtn && dropdownContent) {
+    // Toggle dropdown on button click
+    dropdownBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      dropdownContent.classList.toggle('show');
+    });
+    
+    // Close dropdown when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!dropdownBtn.contains(e.target) && !dropdownContent.contains(e.target)) {
+        dropdownContent.classList.remove('show');
+      }
+    });
+  }
+  
   // Topics Filter Logic
   const topicFilters = document.querySelectorAll('.topic-filter');
   const cards = document.querySelectorAll('.card[data-topic]');
-
   if (topicFilters.length > 0 && cards.length > 0) {
     topicFilters.forEach((checkbox) => {
       checkbox.addEventListener('change', filterCards);
     });
-
     function filterCards() {
       // Get all checked filter values
       const checkedTopics = Array.from(topicFilters)
         .filter((cb) => cb.checked)
         .map((cb) => cb.value);
-
       // Show/hide cards based on filter
       cards.forEach((card) => {
         const cardTopic = card.getAttribute('data-topic');


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
This PR implements a topics filter feature that allows users to filter problem cards by topics on the home page. The implementation includes:

1. **index.html**: Added a filter UI with checkboxes for all topics (Arrays, Linked Lists, Graphs, etc.) above the problem cards section. Each card now has a `data-topic` attribute for filtering.

2. **index.js**: Added JavaScript logic to handle filter checkbox changes and dynamically show/hide problem cards based on selected topics.

3. **CSS/topicsFilter.css**: Created a new CSS file with styles for the topics filter UI, including responsive design for mobile devices and hover effects.

4. **index.html**: Added link to topicsFilter.css in the head section.

Fixes: #55


---

### ✅ Checklist
- [x] My code follows the project's guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue (#55).

---

### 🙌 Additional Notes
The filter functionality uses vanilla JavaScript with no external dependencies. All topic checkboxes are checked by default to show all cards initially. The styling matches the existing design theme.