### PR TITLE
Add breadcrumbs to topic pages

### DIFF
--- a/Arrays/arrays.html
+++ b/Arrays/arrays.html
@@ -27,6 +27,14 @@
       </div>
     </nav>
 
+ <div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Arrays</li>
+  </ul>
+</div>
+
+
   <main>
     <h1>Array Topics</h1>
     <p class="intro-text">

--- a/BinarySearch/binarySearch.html
+++ b/BinarySearch/binarySearch.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -24,6 +25,13 @@
       </div>
     </nav>
   </div>
+
+  <div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Binary Search</li>
+  </ul>
+</div>
 
   <main>
     <h1>Binary Search Topics</h1>

--- a/BinarySearchTrees/bst.html
+++ b/BinarySearchTrees/bst.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Search Trees</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,6 +24,13 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
+
+ <div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Binary Search Trees</li>
+  </ul>
+</div>
 
   <main>
     <h1>Binary Search Tree (BST) Topics</h1>

--- a/BinaryTrees/binaryTrees.html
+++ b/BinaryTrees/binaryTrees.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Binary Trees</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,7 +24,12 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Binary Trees</li>
+  </ul>
+</div>
   <main>
     <h1>Binary Tree Topics</h1>
     <p class="intro-text">

--- a/Dynamic_Programming/dp.html
+++ b/Dynamic_Programming/dp.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Dynamic Programming</title>
+     <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,7 +24,12 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Dynamic Programming</li>
+  </ul>
+</div>
   <main>
     <h1>Dynamic Programming Topics</h1>
     <p class="intro-text">

--- a/Graphs/graph.html
+++ b/Graphs/graph.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Graphs</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,7 +23,13 @@
         </button>
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
-    </nav>
+    </nav>   
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Graphs</li>
+  </ul>
+</div>
 
   <main>
     <h1>Graph Topics</h1>

--- a/Heaps/heap.html
+++ b/Heaps/heap.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Heaps</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,8 +23,13 @@
         </button>
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
-    </nav>
-
+    </nav>  
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Heaps</li>
+  </ul>
+</div>
   <main>
     <h1>Heap Topics</h1>
     <p class="intro-text">

--- a/LinkedList/LL.html
+++ b/LinkedList/LL.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Linked List</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -22,7 +23,13 @@
         </button>
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
-    </nav>
+    </nav> 
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Linked Lists</li>
+  </ul>
+</div>
 
   <main>
     <h1>Linked List Topics</h1>

--- a/Maths/MathProblems.html
+++ b/Maths/MathProblems.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Math Problems</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,7 +24,12 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Math Problems</li>
+  </ul>
+</div>
     <main>
       <h1>Math Problems</h1>
       <p class="intro-text">Explore key mathematical problems commonly encountered in coding interviews.</p>

--- a/Recursion/recursion.html
+++ b/Recursion/recursion.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Recursion</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,7 +24,13 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-
+<link rel="stylesheet" href="../CSS/breadcrumb.css">   
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Recursion</li>
+  </ul>
+</div>
   <main>
     <h1>Recursion Topics</h1>
     <p class="intro-text">

--- a/StacksAndQueues/stackAndQueue.html
+++ b/StacksAndQueues/stackAndQueue.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Stack & Queue</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -24,7 +25,12 @@
       </div>
 
     </nav>
-
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Stacks and Queues</li>
+  </ul>
+</div>
   <main>
     <h1>Stack & Queue Topics</h1>
     <p class="intro-text">

--- a/Strings/String.html
+++ b/Strings/String.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Strings</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,7 +24,13 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-
+<link rel="stylesheet" href="../CSS/breadcrumb.css">   
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Strings</li>
+  </ul>
+</div>
   <main>
     <h1>String Topics</h1>
     <p class="intro-text">

--- a/Tries/tries.html
+++ b/Tries/tries.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Tries</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">   
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -24,8 +25,13 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
-  </div>
-
+  </div> 
+<div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Tries</li>
+  </ul>
+</div>
   <main>
     <h1>Trie Topics</h1>
     <p class="intro-text">

--- a/index.js
+++ b/index.js
@@ -140,6 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
+  
 });
 function navigateTo(page) {
   window.location.href = page;


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

Added breadcrumb navigation to all topic pages in the CodeDSA website. This improves navigation by showing users the path they are on (e.g., Home > Arrays > Two Sum). The breadcrumbs are sticky, mobile-responsive, and consistent across all topics.

Fixes: #84 

---

### 📸 Screenshots (if applicable)

<img width="1918" height="877" alt="497081026-73a2b910-5743-4849-a2a5-5c995320fae9" src="https://github.com/user-attachments/assets/195a5e0b-f7fe-4501-a167-1c2262a4d153" />


---

### ✅ Checklist

- ✅ My code follows the project’s guidelines and style.
- ✅ I have commented my code where necessary.
- ✅ I have updated the documentation if needed.
- ✅ I have tested the changes and confirmed they work as expected.
- ✅ My PR is linked to a GitHub issue.

---

