### PR TITLE
Fix: Remove z-index from Recently Viewed sidebar to prevent overlap.

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -269,7 +269,7 @@ main h1::after {
   padding: 12px 15px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   font-family: sans-serif;
-  z-index: 1000;
+  /*z-index: 1000;*/
 }
 
 /* Custom fix for clock icon misalignment in collapsed state */


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

This PR fixes the issue where the "Recently Viewed" button overlaps the Dark Mode toggle button on the navigation bar. The issue was resolved by removing the `z-index` property from the button’s CSS class, ensuring proper alignment and accessibility.

Fixes: #98 

---

### ✅ Checklist

- [✅ ] My code follows the project’s guidelines and style.
- [✅ ] I have commented my code where necessary.
- [✅ ] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [✅ ] My PR is linked to a GitHub issue.

---
