### PR TITLE
Fix: Remove duplicate Dark Mode toggle on Trie Topics page

### DIFF
--- a/Tries/tries.html
+++ b/Tries/tries.html
@@ -27,7 +27,7 @@
           <span style="margin-left: 20px">Snake Cursor</span>
           <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
         </button>
-        <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
+        <!-- <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button> -->
       </div>
     </nav>
   </div> 


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

This PR fixes a visual bug on the "Trie Topics" page where the Dark Mode toggle button was displayed twice in the top-right corner of the navigation bar.

Fixes: #102 

---
### ✅ Checklist

- [ ✅] My code follows the project’s guidelines and style.
- [ ✅] I have commented my code where necessary.
- [✅ ] I have updated the documentation if needed.
- [✅ ] I have tested the changes and confirmed they work as expected.
- [✅ ] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes

<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->
