### PR TITLE
Fix- Added Breadcrumbs on Divide and Conquer topic page

### DIFF
--- a/DivideAndConquer/DivideAndConquerProblems.html
+++ b/DivideAndConquer/DivideAndConquerProblems.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeDSA Divide and Conquer</title>
+    <link rel="stylesheet" href="../CSS/breadcrumb.css">
     <link rel="stylesheet" href="../CSS/AllTopics.css" />
     <link rel="stylesheet" href="../CSS/snake.css" />
   </head>
@@ -23,6 +24,12 @@
         <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
       </div>
     </nav>
+    <div class="breadcrumb-container">
+  <ul class="breadcrumb">
+    <li class="breadcrumb-item"><a href="../index.html">Home</a></li>
+    <li class="breadcrumb-item active">Divide and Conquer</li>
+  </ul>
+</div>
 
     <main>
       <h1>Divide and Conquer Topics</h1>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

This PR adds the breadcrumb navigation to the Divide and Conquer topic page, which was previously missing. Breadcrumbs improve navigation and help users understand their current location within the site hierarchy.

Fixes: #117 

---

### ✅ Checklist

- [✅] My code follows the project’s guidelines and style.
- [✅] I have commented my code where necessary.
- [✅] I have updated the documentation if needed.
- [✅] I have tested the changes and confirmed they work as expected.
- [✅] My PR is linked to a GitHub issue.

---