### PR TITLE
Fix DSA logo path for GitHub Pages deployment (#106)

### DIFF
--- a/Arrays/Problems/ContainerWater.html
+++ b/Arrays/Problems/ContainerWater.html
@@ -20,13 +20,13 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Arrays/Problems/prodOfArray.html
+++ b/Arrays/Problems/prodOfArray.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Arrays/Problems/subarray.html
+++ b/Arrays/Problems/subarray.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Arrays/Problems/trappingRainwater.html
+++ b/Arrays/Problems/trappingRainwater.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Arrays/Problems/twoSum.html
+++ b/Arrays/Problems/twoSum.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Arrays/arrays.html
+++ b/Arrays/arrays.html
@@ -15,7 +15,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../images/logo.png" alt="Logo">
+        <img src="../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/Problems/basicBinarySearch.html
+++ b/BinarySearch/Problems/basicBinarySearch.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/Problems/firstAndLast.html
+++ b/BinarySearch/Problems/firstAndLast.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/Problems/peakEl.html
+++ b/BinarySearch/Problems/peakEl.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/Problems/searchInsertPos.html
+++ b/BinarySearch/Problems/searchInsertPos.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/Problems/sqrtOrBSOnAnswer.html
+++ b/BinarySearch/Problems/sqrtOrBSOnAnswer.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearch/binarySearch.html
+++ b/BinarySearch/binarySearch.html
@@ -15,7 +15,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../images/logo.png" alt="Logo">
+        <img src="../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/Problems/insertSearchBST.html
+++ b/BinarySearchTrees/Problems/insertSearchBST.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/Problems/kthSmallestLargest.html
+++ b/BinarySearchTrees/Problems/kthSmallestLargest.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/Problems/lowestCommonAncestorBST.html
+++ b/BinarySearchTrees/Problems/lowestCommonAncestorBST.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/Problems/rangeSumBST.html
+++ b/BinarySearchTrees/Problems/rangeSumBST.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/Problems/validateBST.html
+++ b/BinarySearchTrees/Problems/validateBST.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinarySearchTrees/bst.html
+++ b/BinarySearchTrees/bst.html
@@ -15,7 +15,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../images/logo.png" alt="Logo">
+        <img src="../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/Problems/binaryTreePaths.html
+++ b/BinaryTrees/Problems/binaryTreePaths.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/Problems/heightDiameter.html
+++ b/BinaryTrees/Problems/heightDiameter.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/Problems/lowestCommonAncestor.html
+++ b/BinaryTrees/Problems/lowestCommonAncestor.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/Problems/serializeDeserialize.html
+++ b/BinaryTrees/Problems/serializeDeserialize.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/Problems/treeTraversal.html
+++ b/BinaryTrees/Problems/treeTraversal.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/BinaryTrees/binaryTrees.html
+++ b/BinaryTrees/binaryTrees.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/Dynamic_Programming/Problems/0-1Knapsack.html
+++ b/Dynamic_Programming/Problems/0-1Knapsack.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Dynamic_Programming/Problems/catalanNumber.html
+++ b/Dynamic_Programming/Problems/catalanNumber.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Dynamic_Programming/Problems/fibonacciDP.html
+++ b/Dynamic_Programming/Problems/fibonacciDP.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Dynamic_Programming/Problems/longestCommonSubsequence.html
+++ b/Dynamic_Programming/Problems/longestCommonSubsequence.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Dynamic_Programming/Problems/unboundedKnapsack.html
+++ b/Dynamic_Programming/Problems/unboundedKnapsack.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Dynamic_Programming/dp.html
+++ b/Dynamic_Programming/dp.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/Graphs/Problems/bfsDFS.html
+++ b/Graphs/Problems/bfsDFS.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Graphs/Problems/connectedComponents.html
+++ b/Graphs/Problems/connectedComponents.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Graphs/Problems/minSpanningTree.html
+++ b/Graphs/Problems/minSpanningTree.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Graphs/Problems/shortestPath.html
+++ b/Graphs/Problems/shortestPath.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Graphs/Problems/topologicalSort.html
+++ b/Graphs/Problems/topologicalSort.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Graphs/graph.html
+++ b/Graphs/graph.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/GreedyAlgorithms/Problems/activitySelection.html
+++ b/GreedyAlgorithms/Problems/activitySelection.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/GreedyAlgorithms/Problems/fractionalKnapsack.html
+++ b/GreedyAlgorithms/Problems/fractionalKnapsack.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/GreedyAlgorithms/Problems/huffmanEncoding.html
+++ b/GreedyAlgorithms/Problems/huffmanEncoding.html
@@ -16,7 +16,7 @@
 
   <nav class="navbar">
     <div class="logo-container">
-      <div class="logo-img"><img src="../../images/logo.png" alt="Logo"></div>
+      <div class="logo-img"><img src="../../Images/logo.png" alt="Logo"></div>
       <div class="logo">CodeDSA</div>
     </div>
     <div class="nav-right">

--- a/GreedyAlgorithms/Problems/jobScheduling.html
+++ b/GreedyAlgorithms/Problems/jobScheduling.html
@@ -12,7 +12,7 @@
 
 <nav class="navbar">
   <div class="logo-container">
-    <div class="logo-img"><img src="../../images/logo.png" alt="Logo"></div>
+    <div class="logo-img"><img src="../../Images/logo.png" alt="Logo"></div>
     <div class="logo">CodeDSA</div>
   </div>
   <div class="nav-right">

--- a/GreedyAlgorithms/Problems/minPlatforms.html
+++ b/GreedyAlgorithms/Problems/minPlatforms.html
@@ -12,7 +12,7 @@
 
 <nav class="navbar">
   <div class="logo-container">
-    <div class="logo-img"><img src="../../images/logo.png" alt="Logo"></div>
+    <div class="logo-img"><img src="../../Images/logo.png" alt="Logo"></div>
     <div class="logo">CodeDSA</div>
   </div>
   <div class="nav-right">

--- a/GreedyAlgorithms/greedyAlgo.html
+++ b/GreedyAlgorithms/greedyAlgo.html
@@ -15,7 +15,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../images/logo.png" alt="Logo">
+        <img src="../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/Problems/heapSort.html
+++ b/Heaps/Problems/heapSort.html
@@ -19,7 +19,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/Problems/kthLargest.html
+++ b/Heaps/Problems/kthLargest.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/Problems/mergeKSorted.html
+++ b/Heaps/Problems/mergeKSorted.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/Problems/slidingWindowMedian.html
+++ b/Heaps/Problems/slidingWindowMedian.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/Problems/topKFrequent.html
+++ b/Heaps/Problems/topKFrequent.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Heaps/heap.html
+++ b/Heaps/heap.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/LinkedList/LL.html
+++ b/LinkedList/LL.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/LinkedList/Problems/DetectCycle.html
+++ b/LinkedList/Problems/DetectCycle.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/LinkedList/Problems/IntersectionLL.html
+++ b/LinkedList/Problems/IntersectionLL.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/LinkedList/Problems/MergeSortedLL.html
+++ b/LinkedList/Problems/MergeSortedLL.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/LinkedList/Problems/Palindrome.html
+++ b/LinkedList/Problems/Palindrome.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/LinkedList/Problems/ReverseLL.html
+++ b/LinkedList/Problems/ReverseLL.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Maths/MathProblems.html
+++ b/Maths/MathProblems.html
@@ -15,7 +15,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../images/logo.png" alt="Logo">
+        <img src="../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Maths/Problems/Count-Good-Numbers.html
+++ b/Maths/Problems/Count-Good-Numbers.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Maths/Problems/Power-of-two.html
+++ b/Maths/Problems/Power-of-two.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Maths/Problems/largest-permiter-triangle.html
+++ b/Maths/Problems/largest-permiter-triangle.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/Problems/factorial.html
+++ b/Recursion/Problems/factorial.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/Problems/fibonacci.html
+++ b/Recursion/Problems/fibonacci.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/Problems/nQueens.html
+++ b/Recursion/Problems/nQueens.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/Problems/powerSet.html
+++ b/Recursion/Problems/powerSet.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/Problems/stringPermutation.html
+++ b/Recursion/Problems/stringPermutation.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Recursion/recursion.html
+++ b/Recursion/recursion.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
       <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/StacksAndQueues/Problems/ImplementQueueUsingStack.html
+++ b/StacksAndQueues/Problems/ImplementQueueUsingStack.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/StacksAndQueues/Problems/MinStack.html
+++ b/StacksAndQueues/Problems/MinStack.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/StacksAndQueues/Problems/NextGreater.html
+++ b/StacksAndQueues/Problems/NextGreater.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
      <div class="logo-container">
   <div class="logo-img">
-    <img src="../../images/logo.png" alt="Logo">
+    <img src="../../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/StacksAndQueues/Problems/slidingWindowMax.html
+++ b/StacksAndQueues/Problems/slidingWindowMax.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
      <div class="logo-container">
   <div class="logo-img">
-    <img src="../../images/logo.png" alt="Logo">
+    <img src="../../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/StacksAndQueues/Problems/validParentheses.html
+++ b/StacksAndQueues/Problems/validParentheses.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
      <div class="logo-container">
   <div class="logo-img">
-    <img src="../../images/logo.png" alt="Logo">
+    <img src="../../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/StacksAndQueues/stackAndQueue.html
+++ b/StacksAndQueues/stackAndQueue.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
       <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/Strings/Problems/Matching.html
+++ b/Strings/Problems/Matching.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Strings/Problems/groupAnagrams.html
+++ b/Strings/Problems/groupAnagrams.html
@@ -19,7 +19,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Strings/Problems/longestPalinSubstring.html
+++ b/Strings/Problems/longestPalinSubstring.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Strings/Problems/longestSubstringWithoutRepeat.html
+++ b/Strings/Problems/longestSubstringWithoutRepeat.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Strings/Problems/validAnagrams.html
+++ b/Strings/Problems/validAnagrams.html
@@ -18,7 +18,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Strings/String.html
+++ b/Strings/String.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
       <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>

--- a/Tries/Problems/autocomplete.html
+++ b/Tries/Problems/autocomplete.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Tries/Problems/insertSearchTrie.html
+++ b/Tries/Problems/insertSearchTrie.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Tries/Problems/longestCommonPrefix.html
+++ b/Tries/Problems/longestCommonPrefix.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Tries/Problems/prefixCount.html
+++ b/Tries/Problems/prefixCount.html
@@ -17,7 +17,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Tries/Problems/wordSearch.html
+++ b/Tries/Problems/wordSearch.html
@@ -16,7 +16,7 @@
   <nav class="navbar">
     <div class="logo-container">
       <div class="logo-img">
-        <img src="../../images/logo.png" alt="Logo">
+        <img src="../../Images/logo.png" alt="Logo">
       </div>
       <div class="logo">CodeDSA</div>
     </div>

--- a/Tries/tries.html
+++ b/Tries/tries.html
@@ -13,7 +13,7 @@
     <nav class="navbar">
        <div class="logo-container">
   <div class="logo-img">
-    <img src="../images/logo.png" alt="Logo">
+    <img src="../Images/logo.png" alt="Logo">
   </div>
   <div class="logo">CodeDSA</div>
 </div>


### PR DESCRIPTION

## 🚀 Pull Request

### 🔖 Description

Fixes: #106

Corrected the path for the DSA logo image in `index.html`, `about.html`, and `contact.html` to use a relative path (`Images/logo.png`). This resolves the problem where the logo did not appear on GitHub Pages, while it was visible locally.

---

### 📸 Screenshots 
<img width="1920" height="1080" alt="Screenshot (566)" src="https://github.com/user-attachments/assets/b57fb11c-6b88-44e8-b933-a7c56eb0290f" />






Logo now appears beside "CodeDSA" as intended on both localhost and GitHub Pages deployment.

---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes

No major documentation changes required. Learned that relative image paths are necessary for consistency across local and deployed environments.
