### PR TITLE
fix: double navbar issue resolved

### DIFF
--- a/DivideAndConquer/DivideAndConquerProblems.html
+++ b/DivideAndConquer/DivideAndConquerProblems.html
@@ -31,31 +31,6 @@
   </ul>
 </div>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CodeDSA Divide and Conquer</title>
-  <link rel="stylesheet" href="../CSS/AllTopics.css" />
-  <link rel="stylesheet" href="../CSS/snake.css" />
-</head>
-
-<body>
-  <!-- Navbar -->
-  <nav class="navbar">
-    <div class="logo">CodeDSA</div>
-    <div class="nav-right">
-      <ul class="nav-links">
-        <li><a href="../index.html">Home</a></li>
-        <li><a href="../about.html">About</a></li>
-        <li><a href="../contact.html">Contact</a></li>
-      </ul>
-      <button id="snakeToggle" class="snake-btn">
-        <span style="margin-left: 20px">Snake Cursor</span>
-      </button>
-      <button id="darkModeToggle" class="dark-mode-btn">🌙 Dark Mode</button>
-    </div>
-  </nav>
-
   <main>
     <h1>Divide and Conquer Topics</h1>
     <p class="intro-text">


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description

This PR fixes the misaligned layout for divide and conquer page. Successfully removed the double navbar.

Fixes: #138 

---

### 📸 Screenshots (if applicable)
Before
<img width="1366" height="636" alt="image" src="https://github.com/user-attachments/assets/532ce710-a219-48b9-a5c7-da470938ca8e" />
After
<img width="940" height="443" alt="image" src="https://github.com/user-attachments/assets/96c13c83-e611-42b6-8ec8-0996338a4311" />


---

### ✅ Checklist

- [x] My code follows the project’s guidelines and style.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] I have tested the changes and confirmed they work as expected.
- [x] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes

