### PR TITLE
fix: prevent potential integer overflow in binary search midpoint 

### DIFF
--- a/BinarySearch/Problems/basicBinarySearch.html
+++ b/BinarySearch/Problems/basicBinarySearch.html
@@ -78,7 +78,7 @@
 low = 0
 high = n - 1
 while low <= high:
-    mid = (low + high) // 2
+    mid =low + (high-low)//2
     if nums[mid] == target:
         return mid
     else if nums[mid] < target:
@@ -103,7 +103,7 @@ return -1
 function binarySearch(nums, low, high, target):
     if low > high:
         return -1
-    mid = (low + high) // 2
+    mid =low + (high-low)//2
     if nums[mid] == target:
         return mid
     else if nums[mid] < target:


### PR DESCRIPTION
Previously, the code used:
    int mid = (hi + lo) / 2;

This approach can cause integer overflow when `hi` and `lo` are large.
For example:
    lo = 1,000,000,000
    hi = 2,000,000,000
    (hi + lo) = 3,000,000,000  // exceeds 32-bit int limit → overflow

To fix this, the midpoint calculation was updated to:
    int mid = lo + (hi - lo) / 2;

This ensures that the addition never exceeds the valid integer range,
making the binary search safer and more reliable for large input values.



## 🚀 Pull Request

### 🔖 Description

Previously, the code used:
    int mid = (hi + lo) / 2;
    
Updated to:
    int mid = lo + (hi - lo) / 2; 

Fixes: # (issue number)

---

### 📸 Screenshots (if applicable)

<!-- Add screenshots or screen recordings to help us understand your changes. -->

---

### ✅ Checklist

- [ ] My code follows the project’s guidelines and style.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] I have tested the changes and confirmed they work as expected.
- [ ] My PR is linked to a GitHub issue.

---

### 🙌 Additional Notes

<!-- Add anything else you’d like to mention (e.g., learning from this PR, challenges faced). -->
